### PR TITLE
feat(react-linter): extend config with sort import alphabet keys and better prettier integration

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -1,3 +1,7 @@
+const error = 2;
+const warn = 1;
+const ignore = 0;
+
 module.exports = {
   extends: [
     "@socialgouv/eslint-config-recommended",
@@ -23,8 +27,8 @@ module.exports = {
     "html"
   ],
   rules: {
-    "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
+    "react-hooks/rules-of-hooks": error,
+    "react-hooks/exhaustive-deps": warn,
     "simple-import-sort/sort": error,
     "sort-keys-fix/sort-keys-fix": [error, "asc"],
     "import/prefer-default-export": ignore

--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -1,15 +1,33 @@
 module.exports = {
   extends: [
     "@socialgouv/eslint-config-recommended",
+    "airbnb",
     "plugin:jsx-a11y/recommended",
     "plugin:react/recommended",
-    "prettier/react"
+    "prettier",
+    "prettier/react",
+    "plugin:import/errors",
+    "plugin:import/warnings"
   ],
   parser: "babel-eslint",
-  plugins: ["jsx-a11y", "react", "react-hooks"],
+  plugins: [
+    "jsx-a11y",
+    "react",
+    "react-hooks",
+    "sort-keys-fix",
+    "simple-import-sort",
+    "prettier",
+    "import",
+    "jest",
+    "json",
+    "html"
+  ],
   rules: {
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
+    "simple-import-sort/sort": error,
+    "sort-keys-fix/sort-keys-fix": [error, "asc"],
+    "import/prefer-default-export": ignore
   },
   settings: {
     react: {

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -27,9 +27,19 @@
   "dependencies": {
     "@socialgouv/eslint-config-recommended": "^0.9.4",
     "babel-eslint": "^10.0.2",
+    "eslint": "^5.0.1",
     "eslint-plugin-jsx-a11y": "~6.2.3",
     "eslint-plugin-react": "~7.14.3",
-    "eslint-plugin-react-hooks": "~2.0.1"
+    "eslint-plugin-react-hooks": "~2.0.1",
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-config-prettier": "^4.0.0",
+    "eslint-plugin-html": "^5.0.3",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jest": "^22.4.1",
+    "eslint-plugin-json": "^1.4.0",
+    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-simple-import-sort": "^4.0.0",
+    "eslint-plugin-sort-keys-fix": "^1.0.1"
   },
   "devDependencies": {
     "eslint": "^6.2.1",


### PR DESCRIPTION
extend config with sort import alphabet keys and better prettier integration